### PR TITLE
fix(lualine): lualine b section looks unpleasant

### DIFF
--- a/lua/lualine/themes/solarized-osaka.lua
+++ b/lua/lualine/themes/solarized-osaka.lua
@@ -5,7 +5,7 @@ local solarized_osaka = {}
 
 solarized_osaka.normal = {
   a = { bg = colors.blue, fg = colors.black },
-  b = { bg = colors.fg, fg = colors.black },
+  b = { bg = colors.bg_statusline, fg = colors.fg },
   c = { bg = colors.bg_statusline, fg = colors.fg },
 }
 


### PR DESCRIPTION
Fixes #12.
Status info in b section of Lualine was set to use light colors but the bg color was also light:
![2024-01-21_21-43-24](https://github.com/craftzdog/solarized-osaka.nvim/assets/57218218/cfe152dc-6744-450c-a5b7-77452835fd1b)
The original plan was to darken the original `normal.b.bg` (was set to `colors.fg`) a bit, but I just found that using light colors for fg and a lightened variant of `bg_statusline` for bg works better:
![2024-01-22_16-45-50](https://github.com/craftzdog/solarized-osaka.nvim/assets/57218218/842f35fd-4c0e-423d-83f2-1056e23363e3)
What do you think?