### PR TITLE
feat(theme): highlight updates for html,tsx,ts,js,jsx,vue,markdown

### DIFF
--- a/lua/solarized-osaka/colors.lua
+++ b/lua/solarized-osaka/colors.lua
@@ -116,6 +116,7 @@ function M.setup(opts)
   colors.warning = colors.yellow500
   colors.info = colors.blue500
   colors.hint = colors.cyan500
+  colors.todo = colors.violet500
 
   config.options.on_colors(colors)
   if opts.transform and config.is_day() then

--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -320,13 +320,15 @@ function M.setup()
     ["@keyword.tsx"] = { fg = "#768900", style = "italic" },
 
     -- typescript
-    --@variable.typescript
     ["@variable.typescript"] = { fg = c.yellow500 },
 
-    --html
+    -- Vue
+    ["@tag.delimiter.vue"] = { fg = c.orange500 },
+
+    -- html
     ["@tag.delimiter.html"] = { fg = c.orange500 },
 
-    --  javascriptreact
+    -- javascriptreact
     ["@keyword.javascript"] = { fg = "#768900", style = "italic" },
     ["@keyword.return.javascript"] = { fg = "#768900", style = "italic" },
     ["@tag.delimiter.javascript"] = { fg = c.orange500 },
@@ -851,6 +853,13 @@ function M.setup()
       end
     end
   end
+  local markdown_rainbow = { c.blue, c.yellow, c.green, c.red, c.magenta, c.cyan }
+
+  for i, color in ipairs(markdown_rainbow) do
+    theme.highlights["@markup.heading." .. i .. ".markdown"] = { fg = color, bold = true }
+    theme.highlights["Headline" .. i] = { bg = util.darken(color, 0.05) }
+  end
+  theme.highlights["Headline"] = { link = "Headline1" }
 
   ---@type table<string, table>
   theme.defer = {}

--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -316,8 +316,8 @@ function M.setup()
     ["@constructor.tsx"] = { fg = c.blue500 },
     ["@tag.delimiter.tsx"] = { fg = c.orange500 },
     ["@tag.tsx"] = { fg = c.yellow500 },
-    ["@keyword.return.tsx"] = { fg = util.darken(c.green500, 0.85), style = "italic" },
-    ["@keyword.tsx"] = { fg = util.darken(c.green500, 0.85), style = "italic" },
+    ["@keyword.return.tsx"] = { fg = c.green500, style = "italic" },
+    ["@keyword.tsx"] = { fg = c.green500, style = "italic" },
 
     -- typescript
     ["@variable.typescript"] = { fg = c.yellow500 },
@@ -329,8 +329,8 @@ function M.setup()
     ["@tag.delimiter.html"] = { fg = c.orange500 },
 
     -- javascriptreact
-    ["@keyword.javascript"] = { fg = util.darken(c.green500, 0.85), style = "italic" },
-    ["@keyword.return.javascript"] = { fg = util.darken(c.green500, 0.85), style = "italic" },
+    ["@keyword.javascript"] = { fg = c.green500, style = "italic" },
+    ["@keyword.return.javascript"] = { fg = c.green500, style = "italic" },
     ["@tag.delimiter.javascript"] = { fg = c.orange500 },
     ["@tag.javascript"] = { fg = c.yellow500 },
     ["@variable.javascript"] = { fg = c.yellow500 },

--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -859,7 +859,6 @@ function M.setup()
     theme.highlights["@markup.heading." .. i .. ".markdown"] = { fg = color, bold = true }
     theme.highlights["Headline" .. i] = { bg = util.darken(color, 0.05) }
   end
-  theme.highlights["Headline"] = { link = "Headline1" }
 
   ---@type table<string, table>
   theme.defer = {}

--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -332,6 +332,7 @@ function M.setup()
     ["@keyword.return.javascript"] = { fg = "#768900", style = "italic" },
     ["@tag.delimiter.javascript"] = { fg = c.red500 },
     ["@tag.javascript"] = { fg = c.orange500 },
+    ["@variable.javascript"] = { fg = c.yellow500 },
 
     -- LSP Semantic Token Groups
     ["@lsp.type.boolean"] = { link = "@boolean" },

--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -627,7 +627,7 @@ function M.setup()
     LeapBackdrop = { fg = c.base01 },
 
     FlashBackdrop = { fg = c.base01 },
-    FlashLabel = { bg = c.magenta500, bold = true, fg = c.fg },
+    FlashLabel = { bg = c.magenta500, bold = true, fg = c.bg },
 
     LightspeedGreyWash = { fg = c.base01 },
     -- LightspeedCursor = { link = "Cursor" },

--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -316,8 +316,8 @@ function M.setup()
     ["@constructor.tsx"] = { fg = c.blue500 },
     ["@tag.delimiter.tsx"] = { fg = c.orange500 },
     ["@tag.tsx"] = { fg = c.yellow500 },
-    ["@keyword.return.tsx"] = { fg = util.darken(c.green500, 0.8), style = "italic" },
-    ["@keyword.tsx"] = { fg = util.darken(c.green500, 0.8), style = "italic" },
+    ["@keyword.return.tsx"] = { fg = util.darken(c.green500, 0.85), style = "italic" },
+    ["@keyword.tsx"] = { fg = util.darken(c.green500, 0.85), style = "italic" },
 
     -- typescript
     ["@variable.typescript"] = { fg = c.yellow500 },
@@ -329,8 +329,8 @@ function M.setup()
     ["@tag.delimiter.html"] = { fg = c.orange500 },
 
     -- javascriptreact
-    ["@keyword.javascript"] = { fg = util.darken(c.green500, 0.8), style = "italic" },
-    ["@keyword.return.javascript"] = { fg = util.darken(c.green500, 0.8), style = "italic" },
+    ["@keyword.javascript"] = { fg = util.darken(c.green500, 0.85), style = "italic" },
+    ["@keyword.return.javascript"] = { fg = util.darken(c.green500, 0.85), style = "italic" },
     ["@tag.delimiter.javascript"] = { fg = c.orange500 },
     ["@tag.javascript"] = { fg = c.yellow500 },
     ["@variable.javascript"] = { fg = c.yellow500 },

--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -853,12 +853,6 @@ function M.setup()
       end
     end
   end
-  local markdown_rainbow = { c.blue, c.yellow, c.green, c.red, c.magenta, c.cyan }
-
-  for i, color in ipairs(markdown_rainbow) do
-    theme.highlights["@markup.heading." .. i .. ".markdown"] = { fg = color, bold = true }
-    theme.highlights["Headline" .. i] = { bg = util.darken(color, 0.05) }
-  end
 
   ---@type table<string, table>
   theme.defer = {}

--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -316,8 +316,8 @@ function M.setup()
     ["@constructor.tsx"] = { fg = c.blue500 },
     ["@tag.delimiter.tsx"] = { fg = c.orange500 },
     ["@tag.tsx"] = { fg = c.yellow500 },
-    ["@keyword.return.tsx"] = { fg = "#768900", style = "italic" },
-    ["@keyword.tsx"] = { fg = "#768900", style = "italic" },
+    ["@keyword.return.tsx"] = { fg = util.darken(c.green500, 0.8), style = "italic" },
+    ["@keyword.tsx"] = { fg = util.darken(c.green500, 0.8), style = "italic" },
 
     -- typescript
     ["@variable.typescript"] = { fg = c.yellow500 },
@@ -329,8 +329,8 @@ function M.setup()
     ["@tag.delimiter.html"] = { fg = c.orange500 },
 
     -- javascriptreact
-    ["@keyword.javascript"] = { fg = "#768900", style = "italic" },
-    ["@keyword.return.javascript"] = { fg = "#768900", style = "italic" },
+    ["@keyword.javascript"] = { fg = util.darken(c.green500, 0.8), style = "italic" },
+    ["@keyword.return.javascript"] = { fg = util.darken(c.green500, 0.8), style = "italic" },
     ["@tag.delimiter.javascript"] = { fg = c.orange500 },
     ["@tag.javascript"] = { fg = c.yellow500 },
     ["@variable.javascript"] = { fg = c.yellow500 },

--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -313,9 +313,25 @@ function M.setup()
     ["@module"] = { link = "Include" },
 
     -- tsx
-    ["@tag.tsx"] = { fg = c.green500 },
+    -- ["@tag.tsx"] = { fg = c.green500 },
     ["@constructor.tsx"] = { fg = c.blue500 },
     ["@tag.delimiter.tsx"] = { fg = c.orange500 },
+    ["@tag.tsx"] = { fg = c.orange500 },
+    ["@keyword.return.tsx"] = { fg = "#768900", style = "italic" },
+    ["@keyword.tsx"] = { fg = "#768900", style = "italic" },
+
+    -- typescript
+    --@variable.typescript
+    ["@variable.typescript"] = { fg = c.yellow500 },
+
+    --html
+    ["@tag.delimiter.html"] = { fg = c.orange500 },
+
+    --  javascriptreact
+    ["@keyword.javascript"] = { fg = "#768900", style = "italic" },
+    ["@keyword.return.javascript"] = { fg = "#768900", style = "italic" },
+    ["@tag.delimiter.javascript"] = { fg = c.red500 },
+    ["@tag.javascript"] = { fg = c.orange500 },
 
     -- LSP Semantic Token Groups
     ["@lsp.type.boolean"] = { link = "@boolean" },

--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -313,10 +313,9 @@ function M.setup()
     ["@module"] = { link = "Include" },
 
     -- tsx
-    -- ["@tag.tsx"] = { fg = c.green500 },
     ["@constructor.tsx"] = { fg = c.blue500 },
     ["@tag.delimiter.tsx"] = { fg = c.orange500 },
-    ["@tag.tsx"] = { fg = c.orange500 },
+    ["@tag.tsx"] = { fg = c.yellow500 },
     ["@keyword.return.tsx"] = { fg = "#768900", style = "italic" },
     ["@keyword.tsx"] = { fg = "#768900", style = "italic" },
 
@@ -330,8 +329,8 @@ function M.setup()
     --  javascriptreact
     ["@keyword.javascript"] = { fg = "#768900", style = "italic" },
     ["@keyword.return.javascript"] = { fg = "#768900", style = "italic" },
-    ["@tag.delimiter.javascript"] = { fg = c.red500 },
-    ["@tag.javascript"] = { fg = c.orange500 },
+    ["@tag.delimiter.javascript"] = { fg = c.orange500 },
+    ["@tag.javascript"] = { fg = c.yellow500 },
     ["@variable.javascript"] = { fg = c.yellow500 },
 
     -- LSP Semantic Token Groups


### PR DESCRIPTION
I have added a few changes which are more similar to how [tokyonight.nvim](https://github.com/folke/tokyonight.nvim) highlights and also some fixes for `<>` symbols in jsx and html files.

Also added a typescript treesitter tag as they appear white at the moment as they are:
![Screenshot from 2024-03-06 03-54-48](https://github.com/craftzdog/solarized-osaka.nvim/assets/13983258/5d4dd268-ba1f-4f97-b677-6c4c25a5595a)

![Screenshot from 2024-03-06 03-55-01](https://github.com/craftzdog/solarized-osaka.nvim/assets/13983258/933a04cf-6b84-4a26-963e-577dbbe46faf)

- This makes it more consistent to how `.tsx` files are highlighted.
- Also added it for `.js` files so the theme is consistent if the file is `.ts` or `.ts` making all of them consistent.

These are the screenshots for the `.tsx`, `.jsx` and `.html` files showcasing `tsx` and `jsx` being consistently same to each other and also the white `<>` tag fix in both `jsx` and `html`.

![Screenshot from 2024-03-06 04-03-06](https://github.com/craftzdog/solarized-osaka.nvim/assets/13983258/9c7902ac-00e3-48f1-8f4c-37fd0ea5a868)
![Screenshot from 2024-03-06 04-02-47](https://github.com/craftzdog/solarized-osaka.nvim/assets/13983258/5f5d7a2f-a16a-4486-aa14-10fa8d2d63cb)
![Screenshot from 2024-03-06 04-02-36](https://github.com/craftzdog/solarized-osaka.nvim/assets/13983258/22d34a30-af02-416c-ad40-b53912b8d80e)

I tried to be as consistent as i could be for the highlights so it does not ruin the aesthetic of the colorscheme.
The commit can still be edited to suit the colors you might think are not good as they are right now and adjusted according to what your preference might be. 
The goal was to provide the treesittter tags.
Cheers!
