### PR TITLE
bug: Update wezterm theme author and names

### DIFF
--- a/extras/wezterm/solarized-osaka_day.toml
+++ b/extras/wezterm/solarized-osaka_day.toml
@@ -36,5 +36,5 @@ bg_color = "#191b28"
 
 [metadata]
 aliases = []
-author = "folke"
-name = "Tokyo Night Day"
+author = "craftzdog"
+name = "Solarized Osaka Day"

--- a/extras/wezterm/solarized-osaka_moon.toml
+++ b/extras/wezterm/solarized-osaka_moon.toml
@@ -36,5 +36,5 @@ bg_color = "#191b28"
 
 [metadata]
 aliases = []
-author = "folke"
-name = "Tokyo Night Moon"
+author = "craftzdog"
+name = "Solarized Osaka Moon"

--- a/extras/wezterm/solarized-osaka_night.toml
+++ b/extras/wezterm/solarized-osaka_night.toml
@@ -36,5 +36,5 @@ bg_color = "#191b28"
 
 [metadata]
 aliases = []
-author = "folke"
-name = "Tokyo Night"
+author = "craftzdog"
+name = "Solarized Osaka"

--- a/extras/wezterm/solarized-osaka_storm.toml
+++ b/extras/wezterm/solarized-osaka_storm.toml
@@ -36,5 +36,5 @@ bg_color = "#191b28"
 
 [metadata]
 aliases = []
-author = "folke"
-name = "Tokyo Night Storm"
+author = "craftzdog"
+name = "Solarized Osaka Storm"


### PR DESCRIPTION
I updated the color theme metadata for wezterm. This change will make it more clear when calling the Solarized Osaka theme in wezterm configurations instead of calling it "Tokyo Night [something]".