### PR TITLE
fix(theme): support italic text in Markdown files

### DIFF
--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -244,7 +244,7 @@ function M.setup()
     ["@markup.raw"] = { link = "String" },
     ["@markup.math"] = { link = "Special" },
     ["@markup.strong"] = { bold = true },
-    ["@markup.emphasis"] = { italic = true },
+    ["@markup.italic"] = { italic = true },
     ["@markup.strikethrough"] = { strikethrough = true },
     ["@markup.underline"] = { underline = true },
     ["@markup.heading"] = { link = "Title" },


### PR DESCRIPTION
- Treesitter: `@markup.emphasis` -> `@markup.italic`
- https://github.com/nvim-treesitter/nvim-treesitter/blob/722617e6726c1508adadf83d531f54987c703be0/CONTRIBUTING.md?plain=1#L211