### PR TITLE
fix: color alacritty tmux config

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,4 +180,7 @@ To have undercurls show up and in color, add the following to your
 set -g default-terminal "${TERM}"
 set -as terminal-overrides ',*:Smulx=\E[4::%p1%dm'  # undercurl support
 set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'  # underscore colours - needs tmux-3.0
+
+# Alacritty
+set -as terminal-features ",alacritty:RGB"
 ```


### PR DESCRIPTION
I'm sorry, I'm confused about what commit message I want to give because I can't really give a commit message, please help update

before :

![image](https://github.com/craftzdog/solarized-osaka.nvim/assets/69358107/f71a2f47-1504-4b51-adff-0ba1e1df87d3)

after adding this :
```
set -as terminal-features ",alacritty:RGB"
```
![image](https://github.com/craftzdog/solarized-osaka.nvim/assets/69358107/ec3b5cbf-4c2e-417b-b82d-ac4e3f4ec86b)
