### PR TITLE
Add snacks dashboard HL groups and neotree highlights

### DIFF
--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -496,6 +496,7 @@ function M.setup()
     NeoTreeNormal = { fg = c.base00, bg = c.bg_sidebar },
     NeoTreeNormalNC = { fg = c.base00, bg = c.bg_sidebar },
     NeoTreeDimText = { fg = c.base01 },
+    NeoTreeMessage = { fg = util.lighten(c.base02, 0.8) },
 
     -- Fern
     FernBranchText = { fg = c.blue },
@@ -528,6 +529,7 @@ function M.setup()
     SnacksNotifierBorderTrace = { fg = c.magenta500 },
     SnacksNotifierIconTrace = { fg = c.magenta500 },
     SnacksNotifierTitleTrace = { fg = c.magenta500 },
+
     -- Alpha
     AlphaShortcut = { fg = c.orange },
     AlphaHeader = { fg = c.blue },

--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -518,6 +518,16 @@ function M.setup()
     DashboardDesc = { fg = c.cyan500 },
     DashboardIcon = { fg = c.cyan500, bold = true },
 
+    -- Snacks
+    SnacksDashboardDesc = { fg = c.cyan500 },
+    SnacksDashboardKey = { fg = c.orange500 },
+    SnacksDashboardFooter = { fg = c.yellow, italic = true },
+    SnacksDashboardSpecial = { fg = c.yellow500 },
+    SnacksDashboardHeader = { fg = c.blue },
+    SnacksDashboardIcon = { fg = c.cyan500, bold = true },
+    SnacksNotifierBorderTrace = { fg = c.magenta500 },
+    SnacksNotifierIconTrace = { fg = c.magenta500 },
+    SnacksNotifierTitleTrace = { fg = c.magenta500 },
     -- Alpha
     AlphaShortcut = { fg = c.orange },
     AlphaHeader = { fg = c.blue },

--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -496,7 +496,7 @@ function M.setup()
     NeoTreeNormal = { fg = c.base00, bg = c.bg_sidebar },
     NeoTreeNormalNC = { fg = c.base00, bg = c.bg_sidebar },
     NeoTreeDimText = { fg = c.base01 },
-    NeoTreeMessage = { fg = util.lighten(c.base02, 0.8) },
+    NeoTreeMessage = { fg = c.base01 },
 
     -- Fern
     FernBranchText = { fg = c.blue },


### PR DESCRIPTION
Add snacks dashboard highlight groups with same conventions as `dashboard-nvim`.