### PR TITLE
feat(snacks): hl for snacks.indent same to mini.indentscope

### DIFF
--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -529,6 +529,8 @@ function M.setup()
     SnacksNotifierBorderTrace = { fg = c.magenta500 },
     SnacksNotifierIconTrace = { fg = c.magenta500 },
     SnacksNotifierTitleTrace = { fg = c.magenta500 },
+    SnacksIndentScope = { fg = c.violet700, nocombine = true },
+    SnacksIndent = { fg = c.base03, nocombine = true },
 
     -- Alpha
     AlphaShortcut = { fg = c.orange },


### PR DESCRIPTION
Add hl groups for `snacks.indent` to match `mini.indentscope` highlights.