### PR TITLE
Add blink.cmp hl groups and render colors in buffer with hipattern

### DIFF
--- a/.lazy.lua
+++ b/.lazy.lua
@@ -1,0 +1,107 @@
+local M = {
+  module = "solarized-osaka",
+  colorscheme = "solarized-osaka",
+  opts = { plugins = { all = true } },
+  globals = { vim = vim },
+  cache = {},
+}
+
+function M.reset()
+  local colors = require("solarized-osaka.colors").setup()
+  M.globals.colors = colors
+  M.globals.c = colors
+end
+
+---@param name string
+---@param buf number
+function M.hl_group(name, buf)
+  return vim.api.nvim_buf_get_name(buf):find("kinds") and "LspKind" .. name or name
+end
+
+local function reload()
+  for k in pairs(package.loaded) do
+    if k:find("^" .. M.module) then
+      package.loaded[k] = nil
+    end
+  end
+  M.cache = {}
+  require(M.module).setup(M.opts)
+  M.reset()
+  local colorscheme = vim.g.colors_name or M.colorscheme
+  colorscheme = colorscheme:find(M.colorscheme) and colorscheme or M.colorscheme
+  vim.cmd.colorscheme(colorscheme)
+  local hi = require("mini.hipatterns")
+  for _, buf in ipairs(require("mini.hipatterns").get_enabled_buffers()) do
+    hi.update(buf)
+  end
+end
+reload = vim.schedule_wrap(reload)
+
+local augroup = vim.api.nvim_create_augroup("colorscheme_dev", { clear = true })
+vim.api.nvim_create_autocmd("User", {
+  pattern = "VeryLazy",
+  group = augroup,
+  callback = reload,
+})
+vim.api.nvim_create_autocmd("BufWritePost", {
+  group = augroup,
+  pattern = "*/lua/" .. M.module .. "/**.lua",
+  callback = reload,
+})
+
+return {
+  {
+    "echasnovski/mini.hipatterns",
+    opts = function(_, opts)
+      local hi = require("mini.hipatterns")
+
+      opts.highlighters = opts.highlighters or {}
+
+      opts.highlighters = vim.tbl_extend("keep", opts.highlighters or {}, {
+        hex_color = hi.gen_highlighter.hex_color({ priority = 2000 }),
+
+        hl_group = {
+          pattern = function(buf)
+            return vim.api.nvim_buf_get_name(buf):find("lua/" .. M.module) and '^%s*%[?"?()[%w%.@]+()"?%]?%s*='
+          end,
+          group = function(buf, match)
+            local group = M.hl_group(match, buf)
+            if group then
+              if M.cache[group] == nil then
+                M.cache[group] = false
+                local hl = vim.api.nvim_get_hl(0, { name = group, link = false, create = false })
+                if not vim.tbl_isempty(hl) then
+                  hl.fg = hl.fg or vim.api.nvim_get_hl(0, { name = "Normal", link = false }).fg
+                  M.cache[group] = true
+                  vim.api.nvim_set_hl(0, group .. "Dev", hl)
+                end
+              end
+              return M.cache[group] and group .. "Dev" or nil
+            end
+          end,
+          extmark_opts = { priority = 2000 },
+        },
+
+        hl_color = {
+          pattern = {
+            "%f[%w]()c%.[%w_%.]+()%f[%W]",
+            "%f[%w]()colors%.[%w_%.]+()%f[%W]",
+            "%f[%w]()vim%.g%.terminal_color_%d+()%f[%W]",
+          },
+          group = function(_, match)
+            local parts = vim.split(match, ".", { plain = true })
+            local color = vim.tbl_get(M.globals, unpack(parts))
+            return type(color) == "string" and require("mini.hipatterns").compute_hex_color_group(color, "fg")
+          end,
+          extmark_opts = function(_, _, data)
+            return {
+              virt_text = { { "⬤ ", data.hl_group } },
+              virt_text_pos = "inline",
+              priority = 2000,
+            }
+          end,
+        },
+      })
+    end,
+  },
+}

--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -657,9 +657,9 @@ function M.setup()
     LightspeedUnlabeledMatch = { fg = c.violet500, bold = true },
 
     --Blink-cmp
-    --INFO:(BlinkCmpLabel) currently unused by blink.cmp causing colors to use treesitter colors but added when is used
     BlinkCmpLabel = { fg = c.fg, bg = c.none },
     BlinkCmpLabelDeprecated = { fg = c.base01, bg = c.none, strikethrough = true },
+    --INFO: unused at the moment but passed still for future use
     BlinkCmpLabelMatch = { fg = c.violet500, bg = c.none },
 
     -- Documentation windows

--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -657,13 +657,7 @@ function M.setup()
     LightspeedUnlabeledMatch = { fg = c.violet500, bold = true },
 
     --Blink-cmp
-    --INFO: passing bg.none to these causes the menu to be completely invisible not the slightly transparent behavior shown on nvim-cmp
-    -- BlinkCmpMenu = { fg = c.base01, bg = c.none },
-    -- BlinkCmpMenuBorder = { fg = c.base02, bg = c.none },
-    -- BlinkCmpMenuSelection = { fg = c.violet500, bg = c.none },
-    -- BlinkCmpScrollBarThumb = { fg = c.blue, bg = c.none },
-    -- BlinkCmpScrollBarGutter = { fg = c.base02, bg = c.bg },
-
+    --INFO:(BlinkCmpLabel) currently unused by blink.cmp causing colors to use treesitter colors but added when is used
     BlinkCmpLabel = { fg = c.fg, bg = c.none },
     BlinkCmpLabelDeprecated = { fg = c.base01, bg = c.none, strikethrough = true },
     BlinkCmpLabelMatch = { fg = c.violet500, bg = c.none },

--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -656,6 +656,65 @@ function M.setup()
     -- LightspeedUniqueChar = { link = "LightspeedUnlabeledMatch" },
     LightspeedUnlabeledMatch = { fg = c.violet500, bold = true },
 
+    --Blink-cmp
+    --INFO: passing bg.none to these causes the menu to be completely invisible not the slightly transparent behavior shown on nvim-cmp
+    -- BlinkCmpMenu = { fg = c.base01, bg = c.none },
+    -- BlinkCmpMenuBorder = { fg = c.base02, bg = c.none },
+    -- BlinkCmpMenuSelection = { fg = c.violet500, bg = c.none },
+    -- BlinkCmpScrollBarThumb = { fg = c.blue, bg = c.none },
+    -- BlinkCmpScrollBarGutter = { fg = c.base02, bg = c.bg },
+
+    BlinkCmpLabel = { fg = c.fg, bg = c.none },
+    BlinkCmpLabelDeprecated = { fg = c.base01, bg = c.none, strikethrough = true },
+    BlinkCmpLabelMatch = { fg = c.violet500, bg = c.none },
+
+    -- Documentation windows
+    BlinkCmpDoc = { fg = c.fg, bg = c.bg_float },
+    BlinkCmpDocBorder = { fg = c.base02, bg = c.bg_float },
+    BlinkCmpGhostText = { fg = c.base01 },
+
+    -- Signature help
+    BlinkCmpSignatureHelp = { fg = c.violet500, bg = c.none },
+    BlinkCmpSignatureHelpBorder = { fg = c.base02, bg = c.none },
+    BlinkCmpSignatureHelpActiveParameter = { fg = c.orange, bg = c.none },
+
+    -- ISSUE: passing c.none causes menu to be invisible
+    -- BlinkCmpMenu = { fg = c.base01, bg = c.none },
+    BlinkCmpMenu = { fg = c.base01, bg = c.base02 },
+
+    BlinkCmpKindDefault = { fg = c.base01, bg = c.none }, -- Default fallback
+
+    BlinkCmpKindCodeium = { fg = c.cyan500, bg = c.none },
+    BlinkCmpKindCopilot = { fg = c.cyan500, bg = c.none },
+    BlinkCmpKindTabNine = { fg = c.cyan500, bg = c.none },
+    BlinkCmpKindSupermaven = { fg = c.cyan500, bg = c.none },
+
+    BlinkCmpKindKeyword = { fg = c.cyan, bg = c.none },
+    BlinkCmpKindVariable = { fg = c.magenta, bg = c.none },
+    BlinkCmpKindConstant = { fg = c.magenta, bg = c.none },
+    BlinkCmpKindReference = { fg = c.magenta, bg = c.none },
+    BlinkCmpKindValue = { fg = c.magenta, bg = c.none },
+
+    BlinkCmpKindFunction = { fg = c.blue, bg = c.none },
+    BlinkCmpKindMethod = { fg = c.blue, bg = c.none },
+    BlinkCmpKindConstructor = { fg = c.blue, bg = c.none },
+
+    BlinkCmpKindClass = { fg = c.orange, bg = c.none },
+    BlinkCmpKindInterface = { fg = c.orange, bg = c.none },
+    BlinkCmpKindStruct = { fg = c.orange, bg = c.none },
+    BlinkCmpKindEvent = { fg = c.orange, bg = c.none },
+    BlinkCmpKindEnum = { fg = c.orange, bg = c.none },
+    BlinkCmpKindUnit = { fg = c.orange, bg = c.none },
+
+    BlinkCmpKindModule = { fg = c.yellow, bg = c.none },
+
+    BlinkCmpKindProperty = { fg = c.cyan, bg = c.none },
+    BlinkCmpKindField = { fg = c.cyan, bg = c.none },
+    BlinkCmpKindTypeParameter = { fg = c.cyan, bg = c.none },
+    BlinkCmpKindEnumMember = { fg = c.cyan, bg = c.none },
+    BlinkCmpKindOperator = { fg = c.cyan, bg = c.none },
+    BlinkCmpKindSnippet = { fg = c.violet500, bg = c.none },
+
     -- Cmp
     CmpDocumentation = { fg = c.fg, bg = c.bg_float },
     CmpDocumentationBorder = { fg = c.base02, bg = c.bg_float },
@@ -673,6 +732,7 @@ function M.setup()
     CmpItemKindCodeium = { fg = c.cyan500, bg = c.none },
     CmpItemKindCopilot = { fg = c.cyan500, bg = c.none },
     CmpItemKindTabNine = { fg = c.cyan500, bg = c.none },
+    CmpItemKindSupermaven = { fg = c.cyan500, bg = c.none },
 
     CmpItemKindKeyword = { fg = c.cyan, bg = c.none },
     CmpItemKindVariable = { fg = c.magenta, bg = c.none },


### PR DESCRIPTION
First I will tell the issues with `blink.cmp` hl groups that  can't be solved at the moment at least from what I've researched.

- I tested first by using `opts.appearance.use_nvim_cmp_as_default = true` in `blink.cmp` and the issues are same.

### <ins>Seem Solvable</ins>

- The first issue is that setting `BlinkCmpMenu = { fg = c.base01, bg = c.none },` causes the menu to not render and makes it invisible which i could not figure out but from a guess it might be because `blink.cmp` renders these windows with a different attribute compared to `nvim-cmp`. I did check but could not find what was different in both of their documentation.

![image](https://github.com/user-attachments/assets/d2821ea4-3239-4524-bf64-9d57a8fd58d4)

For the time being I've set it to use `BlinkCmpMenu = { fg = c.base01, bg = c.base02 }` as this is the closest to what is defaulted by `nvim-cmp` :

![image](https://github.com/user-attachments/assets/b9c93ace-baca-46d7-bb83-fcd3b92f53e1)

### <ins>Requires upstream changes</ins>
~~- As you might've noticed that the snippets and some completions have different colors in the labels in the completion menus. This is because `blink.cmp` uses treesitter in their menu draw. While this can be solved by passing `opts.completions.menu.draw.treesitter = false` this is something not in our control.~~
- Because I am using LazyVim it passes :
```lua
menu = {
          draw = {
            treesitter = {"lsp"},
          },
        }
```
This was causing it to resolve it use `{"lsp"}` because i used `opts` to pass an empty table so i just checked with using `config` and the default by `blink.cmp` does not use `{"lsp"}` by default so `BlinkCmpLabel` should work fine.

~~- On `blink.cmp` documentation it states that the hl group for this is still unused `BlinkCmpLabel` so I've included it whenever it starts getting used.~~
- The unused symbol is `BlinkCmpLabelMatch`.

### <ins>Small changes</ins>
Also added `supermaven.nvim` kind color for `nvim-cmp` as well.

### <ins>Color rendering in buffer</ins>
- Stole this from `tokyonight.nvim` is `.lazy.lua` file which loads whenever you open the repository and sets up `mini.hipattern` to display and render the colors next to them and also hot reload on changing.
- I did remove the cache part included in his repo cause that is not implemented here and made it usable for this. It can be removed if it is not preferred.
![image](https://github.com/user-attachments/assets/50f9a9b6-aeb0-4ec4-9cf2-df2ac58e6c4f)


If there is anything that is not considered required I will remove it.
I added as reviewer because this pull request has a lot of things in it.

