### PR TITLE
fix(indents): remove reverse so snacks.indent render properly.

### DIFF
--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -83,7 +83,7 @@ function M.setup()
     TabLineFill = { fg = c.base0, bg = c.base02 }, -- tab pages line, where there are no labels
     TabLineSel = { fg = c.yellow500, bg = c.bg }, -- tab pages line, active tab page label
     Title = { fg = c.orange500, bold = true }, -- titles for output from ":set all", ":autocmd" etc.
-    Visual = { bg = c.base03, reverse = true }, -- Visual mode selection
+    Visual = { bg = c.base02 }, -- Visual mode selection
     VisualNOS = { bg = c.base03, reverse = true }, -- Visual mode selection when vim is "Not Owning the Selection".
     WarningMsg = { fg = c.orange500, bold = true }, -- warning messages
     Whitespace = { fg = c.base01 }, -- "nbsp", "space", "tab" and "trail" in 'listchars'


### PR DESCRIPTION
This change removes `reverse` from `Visual` group to ensure that Visual mode selections render properly.
Fixes #53.