### PR TITLE
feat(which-key): consistent float borders with fzf and telescope

### DIFF
--- a/lua/solarized-osaka/theme.lua
+++ b/lua/solarized-osaka/theme.lua
@@ -556,7 +556,7 @@ function M.setup()
     WhichKeyDesc = { fg = c.magenta },
     WhichKeySeperator = { fg = c.base01 },
     WhichKeySeparator = { fg = c.base01 },
-    WhichKeyFloat = { bg = c.bg_sidebar },
+    WhichKeyBorder = { fg = c.base02, bg = c.bg_float },
     WhichKeyValue = { fg = c.violet500 },
 
     -- LspSaga


### PR DESCRIPTION
Change float borders to same as rest being used with `fzf-lua` and `telescope` for consistency.

Old :
![image](https://github.com/user-attachments/assets/2f37f475-8cfb-4616-b19c-b2e6e0417c50)

New : 
![image](https://github.com/user-attachments/assets/8adae695-4587-40f1-bc54-7c82db011429)
