### PR TITLE
fix(colorschemes): only show solarized-osaka and day variant

### DIFF
--- a/colors/solarized-osaka-moon.lua
+++ b/colors/solarized-osaka-moon.lua
@@ -1,1 +1,0 @@
-require("solarized-osaka")._load("moon")

--- a/colors/solarized-osaka-night.lua
+++ b/colors/solarized-osaka-night.lua
@@ -1,1 +1,0 @@
-require("solarized-osaka")._load("night")

--- a/colors/solarized-osaka-storm.lua
+++ b/colors/solarized-osaka-storm.lua
@@ -1,1 +1,0 @@
-require("solarized-osaka")._load("storm")


### PR DESCRIPTION
Clean up of tokyonight multiple variants being shown when they actually do nothing.
Never used colorscheme pickers but using one showed that it was exporting 4 colorschemes which were just different on their names.