### PR TITLE
feat(extras): add Starship theme for Solarized Osaka

### DIFF
--- a/extras/eza/README.md
+++ b/extras/eza/README.md
@@ -1,0 +1,15 @@
+<h3 align="center">
+ Solarized for <a href="https://github.com/eza-community/eza">eza</a>
+</h3>
+
+### About
+
+A Solarized theme for `eza`, a modern replacement for `ls`.
+
+### Usage
+
+1. Copy to `~/.config/eza/theme.yml`
+
+Note: on MacOS, `eza` will look for the theme file in `~/Library/Application Support/eza` by default. That directory can be overridden by setting `EZA_CONFIG_DIR`.
+
+For more information, see [eza-themes](https://github.com/eza-community/eza-themes)

--- a/extras/eza/solarized.yml
+++ b/extras/eza/solarized.yml
@@ -1,0 +1,101 @@
+colourful: true
+filekinds:
+  normal: { foreground: "#839395" }
+  directory: { foreground: "#268bd3" }
+  symlink: { foreground: "#29a298" }
+  pipe: { foreground: "#063540" }
+  block_device: { foreground: "#b28500" }
+  char_device: { foreground: "#b28500" }
+  socket: { foreground: "#063540" }
+  special: { foreground: "#d23681" }
+  executable: { foreground: "#849900" }
+  mount_point: { foreground: "#2aeddd" }
+
+perms:
+  user_read: { foreground: "#29a298" }
+  user_write: { foreground: "#d23681" }
+  user_execute_file: { foreground: "#849900" }
+  user_execute_other: { foreground: "#849900" }
+  group_read: { foreground: "#29a298" }
+  group_write: { foreground: "#ffbf00" }
+  group_execute: { foreground: "#849900" }
+  other_read: { foreground: "#29a298" }
+  other_write: { foreground: "#f254a0" }
+  other_execute: { foreground: "#849900" }
+  special_user_file: { foreground: "#f254a0" }
+  special_other: { foreground: "#db302d" }
+  attribute: { foreground: "#063540" }
+
+size:
+  major: { foreground: "#29a298" }
+  minor: { foreground: "#d23681" }
+  number_byte: { foreground: "#839395" }
+  number_kilo: { foreground: "#46acf5" }
+  number_mega: { foreground: "#29a298" }
+  number_giga: { foreground: "#ffbf00" }
+  number_huge: { foreground: "#f254a0" }
+  unit_byte: { foreground: "#839395" }
+  unit_kilo: { foreground: "#46acf5" }
+  unit_mega: { foreground: "#29a298" }
+  unit_giga: { foreground: "#ffbf00" }
+  unit_huge: { foreground: "#f254a0" }
+
+users:
+  user_you: { foreground: "#268bd3" }
+  user_root: { foreground: "#d23681" }
+  user_other: { foreground: "#29a298" }
+  group_yours: { foreground: "#46acf5" }
+  group_root: { foreground: "#d23681" }
+  group_other: { foreground: "#839395" }
+
+links:
+  normal: { foreground: "#46acf5" }
+  multi_link_file: { foreground: "#29a298" }
+
+git:
+  new: { foreground: "#849900" }
+  modified: { foreground: "#d23681" }
+  deleted: { foreground: "#db302d" }
+  renamed: { foreground: "#29a298" }
+  typechange: { foreground: "#29a298" }
+  ignored: { foreground: "#063540" }
+  conflicted: { foreground: "#ffbf00" }
+
+git_repo:
+  branch_main: { foreground: "#063540" }
+  branch_other: { foreground: "#2aeddd" }
+  git_clean: { foreground: "#001419" }
+  git_dirty: { foreground: "#d23681" }
+
+security_context:
+  colon: { foreground: "#063540" }
+  user: { foreground: "#839395" }
+  role: { foreground: "#29a298" }
+  typ: { foreground: "#268bd3" }
+  range: { foreground: "#d23681" }
+
+file_type:
+  image: { foreground: "#46acf5" }
+  video: { foreground: "#2aeddd" }
+  music: { foreground: "#29a298" }
+  lossless: { foreground: "#29a298" }
+  crypto: { foreground: "#db302d" }
+  document: { foreground: "#839395" }
+  compressed: { foreground: "#ffbf00" }
+  temp: { foreground: "#063540" }
+  compiled: { foreground: "#063540" }
+  build: { foreground: "#1abc9c" }
+  source: { foreground: "#d23681" }
+
+punctuation: { foreground: "#001419" }
+date: { foreground: "#b28500" }
+inode: { foreground: "#063540" }
+blocks: { foreground: "#063540" }
+header: { foreground: "#839395" }
+octal: { foreground: "#ffbf00" }
+flags: { foreground: "#d23681" }
+
+symlink_path: { foreground: "#46acf5" }
+control_char: { foreground: "#ffbf00" }
+broken_symlink: { foreground: "#f254a0" }
+broken_path_overlay: { foreground: "#f254a0" }

--- a/extras/starship/starship.toml
+++ b/extras/starship/starship.toml
@@ -41,6 +41,7 @@ base07 = '#d23681'
 [os]
 disabled = false
 style = "bg:base02 fg:base03"
+format = "[$symbol ]($style)"
 
 [os.symbols]
 Windows = "󰍲"
@@ -64,10 +65,11 @@ Redhat = "󱄛"
 RedHatEnterprise = "󱄛"
 
 [username]
+disabled = true
 show_always = true
 style_user = "bg:base02 fg:base03"
 style_root = "bg:base02 fg:base03"
-format = '[ $user ]($style)'
+format = '[$user ]($style)'
 
 [directory]
 style = "fg:base03 bg:base0"
@@ -97,7 +99,7 @@ style = "bg:base02"
 format = '[[ $symbol( $version) ](fg:base03 bg:base02)]($style)'
 
 [c]
-symbol = " "
+symbol = ""
 style = "bg:base02"
 format = '[[ $symbol( $version) ](fg:base03 bg:base02)]($style)'
 
@@ -117,7 +119,7 @@ style = "bg:base02"
 format = '[[ $symbol( $version) ](fg:base03 bg:base02)]($style)'
 
 [java]
-symbol = " "
+symbol = ""
 style = "bg:base02"
 format = '[[ $symbol( $version) ](fg:base03 bg:base02)]($style)'
 

--- a/extras/starship/starship.toml
+++ b/extras/starship/starship.toml
@@ -1,0 +1,160 @@
+"$schema" = 'https://starship.rs/config-schema.json'
+
+format = """
+[](base02)\
+$os\
+$username\
+[](bg:base0 fg:base02)\
+$directory\
+[](fg:base0 bg:base01)\
+$git_branch\
+$git_status\
+[](fg:base01 bg:base02)\
+$c\
+$rust\
+$golang\
+$nodejs\
+$php\
+$java\
+$kotlin\
+$haskell\
+$python\
+[](fg:base02 bg:base01)\
+$docker_context\
+[](fg:base01 bg:base0)\
+$time\
+[ ](fg:base0)\
+$line_break$character"""
+
+palette = 'solarized_dark'
+
+[palettes.solarized_dark]
+base0 = '#839395'
+base01 = '#002c38'
+base02 = '#268bd3'
+base03 = '#001419'
+base04 = '#849900'
+base05 = '#db302d'
+base06 = '#6d71c4'
+base07 = '#d23681'
+
+[os]
+disabled = false
+style = "bg:base02 fg:base03"
+
+[os.symbols]
+Windows = "󰍲"
+Ubuntu = "󰕈"
+SUSE = ""
+Raspbian = "󰐿"
+Mint = "󰣭"
+Macos = ""
+Manjaro = ""
+Linux = "󰌽"
+Gentoo = "󰣨"
+Fedora = "󰣛"
+Alpine = ""
+Amazon = ""
+Android = ""
+Arch = "󰣇"
+Artix = "󰣇"
+CentOS = ""
+Debian = "󰣚"
+Redhat = "󱄛"
+RedHatEnterprise = "󱄛"
+
+[username]
+show_always = true
+style_user = "bg:base02 fg:base03"
+style_root = "bg:base02 fg:base03"
+format = '[ $user ]($style)'
+
+[directory]
+style = "fg:base03 bg:base0"
+format = "[ $path ]($style)"
+truncation_length = 3
+truncation_symbol = "…/"
+
+[directory.substitutions]
+"Documents" = "󰈙 "
+"Downloads" = " "
+"Music" = "󰝚 "
+"Pictures" = " "
+"Developer" = "󰲋 "
+
+[git_branch]
+symbol = ""
+style = "bg:base01"
+format = '[[ $symbol $branch ](fg:base0 bg:base01)]($style)'
+
+[git_status]
+style = "bg:base01"
+format = '[[($all_status$ahead_behind )](fg:base0 bg:base01)]($style)'
+
+[nodejs]
+symbol = ""
+style = "bg:base02"
+format = '[[ $symbol( $version) ](fg:base03 bg:base02)]($style)'
+
+[c]
+symbol = " "
+style = "bg:base02"
+format = '[[ $symbol( $version) ](fg:base03 bg:base02)]($style)'
+
+[rust]
+symbol = ""
+style = "bg:base02"
+format = '[[ $symbol( $version) ](fg:base03 bg:base02)]($style)'
+
+[golang]
+symbol = ""
+style = "bg:base02"
+format = '[[ $symbol( $version) ](fg:base03 bg:base02)]($style)'
+
+[php]
+symbol = ""
+style = "bg:base02"
+format = '[[ $symbol( $version) ](fg:base03 bg:base02)]($style)'
+
+[java]
+symbol = " "
+style = "bg:base02"
+format = '[[ $symbol( $version) ](fg:base03 bg:base02)]($style)'
+
+[kotlin]
+symbol = ""
+style = "bg:base02"
+format = '[[ $symbol( $version) ](fg:base03 bg:base02)]($style)'
+
+[haskell]
+symbol = ""
+style = "bg:base02"
+format = '[[ $symbol( $version) ](fg:base03 bg:base02)]($style)'
+
+[python]
+symbol = ""
+style = "bg:base02"
+format = '[[ $symbol( $version) ](fg:base03 bg:base02)]($style)'
+
+[docker_context]
+symbol = ""
+style = "bg:base01"
+format = '[[ $symbol( $context) ](fg:base0 bg:base01)]($style)'
+
+[time]
+disabled = false
+time_format = "%R"
+style = "bg:base0"
+format = '[[   $time ](fg:base03 bg:base0)]($style)'
+
+[line_break]
+disabled = false
+
+[character]
+disabled = false
+success_symbol = '[](bold fg:base04)'
+error_symbol = '[](bold fg:base05)'
+vimcmd_symbol = '[](bold fg:base04)'
+vimcmd_replace_one_symbol = '[](bold fg:base06)'
+vimcmd_replace_symbol = '[](bold fg:base06)'
+vimcmd_visual_symbol = '[](bold fg:base07)'


### PR DESCRIPTION
# ✨ Add Starship Theme Configuration  

## 📌 What was done?  
- Added **Starship** theme support in `extras/starship/starship.toml`.  
- The colors follow the **Solarized Osaka** theme.  
- Includes custom icons for operating systems and programming languages.  

## 📋 Why this change?  
This repository aims to provide theme support for multiple tools.  
This PR adds support for **Starship**, allowing users to have a prompt that matches the **Solarized Osaka** color scheme.  

## 📸 Preview  
![Starship theme preview](https://i.postimg.cc/QdvxyBX5/screenshot-01042025-153610.jpg)
![Starship theme preview](https://i.postimg.cc/xdhgxNTW/screenshot-02042025-093847.jpg)

Let me know if any changes are needed! 😊  
