### PR TITLE
fix(bufferline): add nocombine for hl groups merging with `TabLine`

### DIFF
--- a/lua/solarized-osaka/groups/bufferline.lua
+++ b/lua/solarized-osaka/groups/bufferline.lua
@@ -4,6 +4,7 @@ function M.get(c, opts)
   --stylua: ignore
   return {
     BufferLineIndicatorSelected = { fg = c.yellow500 },
+    TabLineFill                 = { nocombine = true }
   }
 end
 


### PR DESCRIPTION
On nvim 0.11 the highlight groups are merged with `TabLine` now instead of `Normal` and using nocombine fixes this issue.