### PR TITLE
fix(highlights): don't override default sp colors

### DIFF
--- a/.lazy.lua
+++ b/.lazy.lua
@@ -50,7 +50,7 @@ vim.api.nvim_create_autocmd("BufWritePost", {
 
 return {
   {
-    "echasnovski/mini.hipatterns",
+    "nvim-mini/mini.hipatterns",
     opts = function(_, opts)
       local hi = require("mini.hipatterns")
 

--- a/lua/solarized-osaka/groups/editor.lua
+++ b/lua/solarized-osaka/groups/editor.lua
@@ -9,7 +9,7 @@ function M.get(c, options)
     lCursor                     = { fg = c.base03, bg = c.base00 }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
     CursorIM                    = { fg = c.base03, bg = c.base0 }, -- like Cursor, but used when in IME mode |CursorIM|
     CursorColumn                = { bg = c.base02 }, -- Screen-column at the cursor, when 'cursorcolumn' is set.
-    CursorLine                  = { bg = c.base03, sp = c.base1 }, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
+    CursorLine                  = { bg = c.base03 }, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
     Directory                   = { fg = c.blue500 }, -- directory names (and other special names in listings)
     DiffAdd                     = { fg = c.green500, bg = c.base02, bold = true }, -- diff mode: Added line |diff.txt|
     DiffChange                  = { fg = c.yellow500, bg = c.base02, bold = true }, -- diff mode: Changed line |diff.txt|


### PR DESCRIPTION
Fix #75 

Explicitly setting `sp` for `CursorLine` now works in nightly and overrides highlights for all Special chars.

Also fix for the name change of `mini-hipattern`.