### PR TITLE
Better visibility in nvimdiff

### DIFF
--- a/lua/solarized-osaka/groups/editor.lua
+++ b/lua/solarized-osaka/groups/editor.lua
@@ -11,9 +11,9 @@ function M.get(c, options)
     CursorColumn                = { bg = c.base02 }, -- Screen-column at the cursor, when 'cursorcolumn' is set.
     CursorLine                  = { bg = c.base03 }, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
     Directory                   = { fg = c.blue500 }, -- directory names (and other special names in listings)
-    DiffAdd                     = { fg = c.green500, bg = c.base02, bold = true }, -- diff mode: Added line |diff.txt|
-    DiffChange                  = { fg = c.yellow500, bg = c.base02, bold = true }, -- diff mode: Changed line |diff.txt|
-    DiffDelete                  = { fg = c.red500, bg = c.base02, bold = true }, -- diff mode: Deleted line |diff.txt|
+    DiffAdd                     = { fg = c.green500, bg = c.base04, bold = true }, -- diff mode: Added line |diff.txt|
+    DiffChange                  = { fg = c.yellow500, bg = c.base04, bold = true }, -- diff mode: Changed line |diff.txt|
+    DiffDelete                  = { fg = c.red500, bg = c.base04, bold = true }, -- diff mode: Deleted line |diff.txt|
     DiffText                    = { fg = c.blue500, bg = c.base02, bold = true }, -- diff mode: Changed text within a changed line |diff.txt|
     EndOfBuffer                 = { fg = c.base01 }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
     -- TermCursor  = { }, -- cursor in a focused terminal

--- a/lua/solarized-osaka/groups/editor.lua
+++ b/lua/solarized-osaka/groups/editor.lua
@@ -11,10 +11,10 @@ function M.get(c, options)
     CursorColumn                = { bg = c.base02 }, -- Screen-column at the cursor, when 'cursorcolumn' is set.
     CursorLine                  = { bg = c.base03 }, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
     Directory                   = { fg = c.blue500 }, -- directory names (and other special names in listings)
-    DiffAdd                     = { fg = c.green500, bg = c.base04, bold = true }, -- diff mode: Added line |diff.txt|
-    DiffChange                  = { fg = c.yellow500, bg = c.base04, bold = true }, -- diff mode: Changed line |diff.txt|
-    DiffDelete                  = { fg = c.red500, bg = c.base04, bold = true }, -- diff mode: Deleted line |diff.txt|
-    DiffText                    = { fg = c.blue500, bg = c.base02, bold = true }, -- diff mode: Changed text within a changed line |diff.txt|
+    DiffAdd                     = { bg = c.base04, bold = true }, -- diff mode: Added line |diff.txt|
+    DiffChange                  = { bg = c.base04, bold = true }, -- diff mode: Changed line |diff.txt|
+    DiffDelete                  = { bg = c.base04, bold = true }, -- diff mode: Deleted line |diff.txt|
+    DiffText                    = { bg = c.base02, bold = true }, -- diff mode: Changed text within a changed line |diff.txt|
     EndOfBuffer                 = { fg = c.base01 }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
     -- TermCursor  = { }, -- cursor in a focused terminal
     -- TermCursorNC= { }, -- cursor in an unfocused terminal


### PR DESCRIPTION
# Diff mode (nvimdiff) color visability

- Two changes below in hopes to increase visability in diff mode. 

## Highlight visability

- Previously was unable to spot highlighted lines (visual mode) in nvimdiff. 
  - Solves https://github.com/craftzdog/solarized-osaka.nvim/issues/78 
- I have changed DiffChange/Add/Delete from base02 to base04
  - Have tried base03 but visibility is poor
  - Have also tried to change DiffText to base01 but it is too bright

## Syntax highlighting

- Removed font colors in nvimdiff to bring back syntax highlighting
- Understand this is personal taste and happy to shelf this change if this is unfavourable.

## Before after screenshots

- Before
<img width="2493" height="329" alt="image" src="https://github.com/user-attachments/assets/57b26c2e-fa64-4265-8d0a-03344b789c58" />

- After
<img width="2493" height="329" alt="image" src="https://github.com/user-attachments/assets/ce8fe0b6-1f81-4b09-ab55-5fa08b03ca01" />

